### PR TITLE
Allow concurrent access to database

### DIFF
--- a/server/actions/elections.go
+++ b/server/actions/elections.go
@@ -70,7 +70,6 @@ func CreateElection(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	election := database.Election{
 		ID:            uuid.NewV4(),
 		Name:          body.Name,
@@ -135,7 +134,6 @@ func EditElection(c *gin.Context) {
 
 	election := database.Election{ID: electionId}
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	if err := db.Preload("Candidates").First(&election).Error; err != nil {
 		fmt.Println(err)
 		c.String(http.StatusBadRequest, util.InvalidElection)
@@ -179,7 +177,6 @@ func setElectionPublishedStatus(c *gin.Context, publishedStatus bool) {
 
 	election := database.Election{ID: electionId}
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	if err := db.Preload("Candidates").First(&election).Error; err != nil {
 		fmt.Println(err)
 		c.String(http.StatusBadRequest, util.InvalidElection)
@@ -219,7 +216,6 @@ func FinalizeElection(c *gin.Context) {
 
 	election := database.Election{ID: electionId}
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	if err := db.Preload("Candidates").First(&election).Error; err != nil {
 		fmt.Println(err)
 		c.String(http.StatusBadRequest, util.InvalidElection)
@@ -248,7 +244,6 @@ func DeleteElection(c *gin.Context) {
 
 	election := database.Election{ID: electionId}
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	if err := db.Preload("Votes").First(&election).Error; err != nil {
 		fmt.Println(err)
 		c.String(http.StatusBadRequest, util.InvalidElection)
@@ -286,7 +281,6 @@ func GetElection(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	election := database.Election{ID: electionId}
 	if err := db.Preload("Candidates").First(&election).Error; err != nil {
@@ -302,7 +296,6 @@ func GetElection(c *gin.Context) {
 // candidates in the elections.
 func GetElections(c *gin.Context) {
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	var elections []database.Election
 	if err := db.Preload("Candidates").Find(&elections).Error; err != nil {
@@ -322,7 +315,6 @@ func GetElections(c *gin.Context) {
 // published flag set to true.
 func GetPublicElections(c *gin.Context) {
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	var elections []database.Election
 	if err := db.Preload("Candidates").Find(&elections).Error; err != nil {
@@ -354,7 +346,6 @@ func GetPublicElection(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	// election := database.FetchElectionIfPublic(db, electionId)
 
 	election := database.Election{ID: electionId}
@@ -391,7 +382,6 @@ func AddCandidate(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	election := database.Election{ID: electionId}
 	if err := db.Preload("Votes").First(&election).Error; err != nil {
@@ -452,7 +442,6 @@ func EditCandidate(c *gin.Context) {
 
 	candidate := database.Candidate{ID: candidateId}
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	if err := db.First(&candidate).Error; err != nil {
 		fmt.Println(err)
 		c.String(http.StatusBadRequest, "Invalid candidate specified")
@@ -486,7 +475,6 @@ func RemoveCandidate(c *gin.Context) {
 
 	candidate := database.Candidate{ID: candidateId}
 	db := database.GetDB()
-	defer database.ReleaseDB()
 	if err := db.Preload("Election.Votes").First(&candidate).Error; err != nil {
 		c.String(http.StatusBadRequest, "Invalid candidate specified")
 		return

--- a/server/actions/voters.go
+++ b/server/actions/voters.go
@@ -34,7 +34,6 @@ func AddVoters(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	if err := db.Clauses(clause.OnConflict{DoNothing: true}).Create(&voters).Error; err != nil {
 		fmt.Println(err)
@@ -70,7 +69,6 @@ func RemoveVoters(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	if err := db.Delete(&voters).Error; err != nil {
 		fmt.Println(err)
@@ -90,7 +88,6 @@ func RemoveVoters(c *gin.Context) {
 // GetVoters fetches all current allowed voters from the database
 func GetVoters(c *gin.Context) {
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	result, err := getAllVoters(db)
 	if err != nil {

--- a/server/actions/votes.go
+++ b/server/actions/votes.go
@@ -125,12 +125,12 @@ func CastVote(c *gin.Context) {
 	// by correlating positions in the database tables.
 	// Raises the time complexity of the vote operation a lot, but should be
 	// fine for the amount of traffic expected for this system.
-	if err := database.ReorderRows(db, "casted_votes"); err != nil {
-		fmt.Println("Database failed to shuffle table casted_votes")
-	}
-	if err := database.ReorderRows(db, "vote_hashes"); err != nil {
-		fmt.Println("Database failed to shuffle table vote_hashes")
-	}
+	// if err := database.ReorderRows(db, "casted_votes"); err != nil {
+	// 	fmt.Println("Database failed to shuffle table casted_votes")
+	// }
+	// if err := database.ReorderRows(db, "vote_hashes"); err != nil {
+	// 	fmt.Println("Database failed to shuffle table vote_hashes")
+	// }
 
 	c.String(http.StatusOK, hash)
 }

--- a/server/actions/votes.go
+++ b/server/actions/votes.go
@@ -51,7 +51,6 @@ func CastVote(c *gin.Context) {
 	var hash string
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	// Validation section
 	// Check that election is open for voting, that the user hasn't voted already,
@@ -147,7 +146,6 @@ func GetVotes(c *gin.Context) {
 	}
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	var votes []database.Vote
 	if err := db.Preload("Rankings").Find(&votes, "election_id = ?", electionId).Error; err != nil {
@@ -201,7 +199,6 @@ func CountVotes(c *gin.Context) {
 		c.String(http.StatusBadRequest, util.InvalidElection)
 		return
 	}
-	database.ReleaseDB()
 	if !election.Finalized {
 		c.String(http.StatusBadRequest, "Can't count votes of unfinalized election")
 		return
@@ -312,7 +309,6 @@ func CountVotesSchultze(c *gin.Context) {
 		c.String(http.StatusBadRequest, util.InvalidElection)
 		return
 	}
-	database.ReleaseDB()
 	if !election.Finalized {
 		c.String(http.StatusBadRequest, "Can't count votes of unfinalized election")
 		return
@@ -412,7 +408,6 @@ func GetHashes(c *gin.Context) {
 	// TODO: possibly add electionID to database for hashes, since it would be nice
 	// to be able to filter by that and only allow fetching from finalized elections
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	var hashes []database.VoteHash
 	if err := db.Find(&hashes).Error; err != nil {
@@ -440,7 +435,6 @@ func HasVoted(c *gin.Context) {
 	user := c.GetString("user")
 
 	db := database.GetDB()
-	defer database.ReleaseDB()
 
 	if db.Find(&database.CastedVote{ElectionID: electionId, Email: user}).RowsAffected == 0 {
 		c.String(http.StatusOK, "false")

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -3,7 +3,6 @@ package db
 import (
 	"fmt"
 	"os"
-	"sync"
 
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -12,7 +11,6 @@ import (
 )
 
 var db *gorm.DB
-var m sync.Mutex
 
 func InitDB() {
 	c := config.GetConfig()
@@ -33,12 +31,7 @@ func InitDB() {
 }
 
 func GetDB() *gorm.DB {
-	m.Lock()
 	return db
-}
-
-func ReleaseDB() {
-	m.Unlock()
 }
 
 // ReorderRows shuffles the rows in the specified table

--- a/server/middleware/voting.go
+++ b/server/middleware/voting.go
@@ -19,10 +19,8 @@ func AllowedToVote() gin.HandlerFunc {
 		if db.Find(&database.ValidVoter{Email: user}).RowsAffected == 0 {
 			c.String(http.StatusForbidden, "Not registered as a valid voter")
 			c.Abort()
-			database.ReleaseDB()
 			return
 		}
-		database.ReleaseDB()
 		c.Next()
 	}
 }


### PR DESCRIPTION
I have looked through all places that called `database.GetDB` and I don't think that there should be any big problems. It will probably be possible for one admin to finalize an election at the same time as when one is updating it, which doesn't seem good, but shouldn't be a huge problem since it still can't be updated more than a few seconds (given a lot of latency) afterwards.

Not 100% sure though!